### PR TITLE
Gui: safe a mouse click: use checkboxes instead of dropdown for logx, logy, logz

### DIFF
--- a/qt4/Go4GUI/TGo4HisDrawOptions.cpp
+++ b/qt4/Go4GUI/TGo4HisDrawOptions.cpp
@@ -35,9 +35,9 @@ TGo4HisDrawOptions::TGo4HisDrawOptions( QWidget* parent, const char *name, Qt::W
    QObject::connect(DrawOption, QOverload<int>::of(&QComboBox::activated), this, &TGo4HisDrawOptions::SetDrawOptions);
    QObject::connect(ErrorBars, QOverload<int>::of(&QComboBox::activated), this, &TGo4HisDrawOptions::SetErrorBars);
    QObject::connect(Coordinates, QOverload<int>::of(&QComboBox::activated), this, &TGo4HisDrawOptions::SetCoordinates);
-   QObject::connect(XStyle, QOverload<int>::of(&QComboBox::activated), this, &TGo4HisDrawOptions::XaxisStyle);
-   QObject::connect(YStyle, QOverload<int>::of(&QComboBox::activated), this, &TGo4HisDrawOptions::YaxisStyle);
-   QObject::connect(ZStyle, QOverload<int>::of(&QComboBox::activated), this, &TGo4HisDrawOptions::ZaxisStyle);
+   QObject::connect(LogX, &QCheckBox::toggled, this, &TGo4HisDrawOptions::XaxisStyle);
+   QObject::connect(LogY, &QCheckBox::toggled, this, &TGo4HisDrawOptions::YaxisStyle);
+   QObject::connect(LogZ, &QCheckBox::toggled, this, &TGo4HisDrawOptions::ZaxisStyle);
    QObject::connect(AutoScaleBox, &QCheckBox::toggled, this, &TGo4HisDrawOptions::SetAutoScale);
    QObject::connect(LineColor, &QPushButton::clicked, this, &TGo4HisDrawOptions::SetLineColor);
    QObject::connect(FillColor, &QPushButton::clicked, this, &TGo4HisDrawOptions::SetFillColor);
@@ -105,10 +105,10 @@ void TGo4HisDrawOptions::panelSlot(TGo4ViewPanel* panel, TPad* pad, int signalid
          DrawOption->setCurrentIndex(DrawStyle);
          ErrorBars->setCurrentIndex(ErrorStyle);
          Coordinates->setCurrentIndex(CoordStyle);
-         XStyle->setCurrentIndex(padopt->GetLogScale(0));
-         YStyle->setCurrentIndex(padopt->GetLogScale(1));
-         ZStyle->setCurrentIndex(padopt->GetLogScale(2));
-         ZStyle->setEnabled(ndim>1);
+         LogX->setChecked(padopt->GetLogScale(0));
+         LogY->setChecked(padopt->GetLogScale(1));
+         LogZ->setChecked(padopt->GetLogScale(2));
+         LogZ->setEnabled(ndim>1);
          AutoScaleBox->setChecked(padopt->IsAutoScale());
 
          LineColor->setEnabled(dynamic_cast<TAttLine*>(obj) != nullptr);
@@ -321,17 +321,17 @@ void TGo4HisDrawOptions::SetCoordinates( int t )
    ChangeDrawOptionForCurrentPanel(2, t);
 }
 
-void TGo4HisDrawOptions::XaxisStyle( int t )
+void TGo4HisDrawOptions::XaxisStyle( bool t )
 {
    ChangeDrawOptionForCurrentPanel(3, t);
 }
 
-void TGo4HisDrawOptions::YaxisStyle( int t )
+void TGo4HisDrawOptions::YaxisStyle( bool t )
 {
     ChangeDrawOptionForCurrentPanel(4, t);
 }
 
-void TGo4HisDrawOptions::ZaxisStyle( int t )
+void TGo4HisDrawOptions::ZaxisStyle( bool t )
 {
    ChangeDrawOptionForCurrentPanel(5, t);
 }

--- a/qt4/Go4GUI/TGo4HisDrawOptions.h
+++ b/qt4/Go4GUI/TGo4HisDrawOptions.h
@@ -49,9 +49,9 @@ class TGo4HisDrawOptions : public QWidget, public Ui::TGo4HisDrawOptions
     virtual void SetDrawOptions(int t);
     virtual void SetErrorBars(int t);
     virtual void SetCoordinates(int t);
-    virtual void XaxisStyle(int t);
-    virtual void YaxisStyle(int t);
-    virtual void ZaxisStyle(int t);
+    virtual void XaxisStyle(bool t);
+    virtual void YaxisStyle(bool t);
+    virtual void ZaxisStyle(bool t);
     virtual void SetAutoScale(bool on);
     virtual void SetLineColor();
     virtual void SetFillColor();

--- a/qt4/Go4GUI/TGo4HisDrawOptions.ui
+++ b/qt4/Go4GUI/TGo4HisDrawOptions.ui
@@ -35,45 +35,24 @@
         <widget class="QComboBox" name="Coordinates" />
       </item>
       <item row="0" column="3" >
-        <widget class="QComboBox" name="XStyle" >
-          <item>
-            <property name="text" >
-              <string>X: Lin</string>
-            </property>
-          </item>
-          <item>
-            <property name="text" >
-              <string>X: Log</string>
-            </property>
-          </item>
+        <widget class="QCheckBox" name="LogX" >
+          <property name="text" >
+            <string>LogX</string>
+          </property>
         </widget>
       </item>
       <item row="0" column="4" >
-        <widget class="QComboBox" name="YStyle" >
-          <item>
-            <property name="text" >
-              <string>Y: Lin</string>
-            </property>
-          </item>
-          <item>
-            <property name="text" >
-              <string>Y: Log</string>
-            </property>
-          </item>
+        <widget class="QCheckBox" name="LogY" >
+          <property name="text" >
+            <string>LogY</string>
+          </property>
         </widget>
-      </item>
+	</item>
       <item row="0" column="5" >
-        <widget class="QComboBox" name="ZStyle" >
-          <item>
-            <property name="text" >
-              <string>Z: Lin</string>
+        <widget class="QCheckBox" name="LogZ" >
+	   <property name="text" >
+              <string>LogZ</string>
             </property>
-          </item>
-          <item>
-            <property name="text" >
-              <string>Z: Log</string>
-            </property>
-          </item>
         </widget>
       </item>
       <item row="0" column="6" >


### PR DESCRIPTION
The logness dropdown menus have only two options: lin and log. I think it is unlikely that ROOT will add a third setting. By using a checkbox, we can decrease the mouse clicks used to toggle by 50%. 