### PR TITLE
stretch/qt5.7 compatibility, avoiding qt5.8 functions.

### DIFF
--- a/qt4/Go4GUI/TGo4HttpProxy.cpp
+++ b/qt4/Go4GUI/TGo4HttpProxy.cpp
@@ -422,7 +422,7 @@ void TGo4HttpAccess::httpFinished()
          const char *value = xml->GetAttr(chld, "value");
          if (time && value) {
             QDateTime tm = QDateTime::fromString(time, Qt::ISODate);
-            gr->SetPoint(i, tm.toSecsSinceEpoch(), TString(value).Atof());
+            gr->SetPoint(i, tm.toMSecsSinceEpoch()/1000, TString(value).Atof());
             i = (i+1) % cnt;
          }
          chld = (chld==top) ? xml->GetChild(top) : xml->GetNext(chld);

--- a/qt4/Go4GUI/TGo4LogInfo.cpp
+++ b/qt4/Go4GUI/TGo4LogInfo.cpp
@@ -96,7 +96,7 @@ void TGo4LogInfo::linkedObjectUpdated(const char *linkname, TObject *linkobj)
          Long64_t tm = TString(msg, separ-msg).Atoll();
 
          QDateTime dt;
-         dt.setSecsSinceEpoch(tm);
+         dt.setMSecsSinceEpoch(tm*1000);
 
          separ++;
          int level = 1;


### PR DESCRIPTION
We are currently still running debian stretch (LTS until 2022-06-30) on our main analysis machine (lxir136), which includes QT 5.7, which in turn does not yet include get/[setSecsSinceEpoch](https://doc.qt.io/qt-6/qdatetime.html#setSecsSinceEpoch), but only the millisecond version. 

I am 90% certain that we will manage to update to at least debian buster before the the milliseconds since epoch overflow for uint64_t (in about 585 million years). 