### PR TITLE
use CXX/CC environment variables to set the compiler commands

### DIFF
--- a/build/Makefile.Linux
+++ b/build/Makefile.Linux
@@ -7,11 +7,11 @@ DllSuf        = so
 
 #### Compilers: ####
 ifdef clang
-CXX           = clang++
-CC            = clang
+CXX           ?= clang++
+CC            ?= clang
 else
-CXX           = g++
-CC            = gcc
+CXX           ?= g++
+CC            ?= gcc
 endif
 
 #### Compiler optimization flags: ####
@@ -37,11 +37,11 @@ LDFLAGS_RPATH = $(LDRPATHS:%=-Wl,-rpath,%)
 endif
 
 ifdef clang
-LD            = clang++
+LD            = $(CXX)
 LDFLAGS       += $(LDFLAGS_RPATH) $(LDFLAGS_EXTRA) -O
 SOFLAGS       = -shared -Wl,-soname,
 else
-LD            = g++
+LD            = $(CXX)
 LDFLAGS       += $(LDFLAGS_RPATH) -Wl,--no-as-needed $(LDFLAGS_EXTRA) -O
 SOFLAGS       = -shared -Wl,-soname,
 endif


### PR DESCRIPTION
Hi!

For the build process on conda-forge the issue came up, that conda-forge actually provides the compiler that should be used for packaging via the `CXX` environment variable. See also the [discussion](https://github.com/conda-forge/staged-recipes/pull/30301#discussion_r2554581920) 

I can build the packages now by applying a [patch](https://github.com/conda-forge/staged-recipes/pull/30301/files#diff-705840f381856af6b51a7619b455c6c179a8e7de5c81169ae207457a58115330
) before building, but maybe you want to take over that behaviour instead?
It only affects the "make" based build on Linux when I test if Go4 can run `Go4ExampleSimple` and `Go4ExampleUserSource`. It's not necessary for building Go4 itself with CMake.

The previous setting to g++/clang++ is now the fallback default value.
