### PR TITLE
Analysing TGo4Analysis class with AI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,177 @@
+# AGENTS.md — Go4 Project Guide for AI Agents
+
+## Project Overview
+
+**Go4** (GSI Online Offline Object Oriented) is a C++ framework for experiment data processing, developed at the EE department of GSI Helmholtz Centre for Heavy Ion Research. It provides infrastructure for online and offline analysis of experimental physics data.
+
+- **Version**: v6.4.0 (build 60400), March 2025
+- **License**: GNU General Public License v2 or later
+- **Language**: C++ (`.cxx` / `.h` files)
+- **Build System**: CMake (minimum 3.10)
+- **Dependencies**: ROOT >= 6.28, Qt5 >= 5.12 or Qt6 >= 6.4
+- **Total Source Files**: ~965 (`.cxx`, `.h`, `.cpp`, `.hpp`)
+
+## Architecture
+
+The project follows a modular library architecture with clear dependency layers:
+
+### Dependency Layers
+
+```
+Layer 1 (Base):     Go4LockGuard, Go4Log, Go4Exceptions, Go4CommandsBase, Go4StatusBase
+                           ↓
+Layer 2 (Core):     Go4Base (aggregates Layer 1 + ROOT dict)
+                           ↓
+Layer 3 (Thread):   Go4ThreadManager
+                           ↓
+Layer 4 (Task):     Go4Socket, Go4Queue, Go4TaskHandler, Go4CommandsTaskHandler
+                           ↓
+Layer 5 (AnalBase): Go4Event, Go4EventServer, Go4ConditionsBase, Go4DynamicList,
+                    Go4StatusAnalysis, Go4Analysis, MbsAPIbase, Go4HDF5 (optional)
+                           ↓
+Layer 6 (Analysis): MbsAPI, RawAPI (optional), Go4HistogramServer,
+                    Go4CommandsAnalysis, Go4AnalysisClient, Go4Http (optional)
+                           ↓
+Layer 7 (GUI):      Go4ObjectManager, Go4Display, Go4Proxies → qt4/
+```
+
+### Key Directories
+
+| Directory | Purpose |
+|-----------|---------|
+| `Go4Base*` | Foundation modules (logging, exceptions, commands, status) |
+| `Go4ThreadManager` | Thread pool and task scheduling |
+| `Go4TaskHandler` | Client-server task management via sockets |
+| `Go4Analysis*` | Core analysis framework (steps, events, conditions) |
+| `Go4Commands*` | Command pattern implementations for remote control |
+| `Go4ConditionsBase` | Data visualization conditions (polygon, window, etc.) |
+| `Go4Dict` | ROOT dictionary linkdef headers |
+| `qt4/` | Qt GUI applications (go4gui, web interface) |
+| `Go4Example*/` | Example analysis implementations |
+| `cmake/modules/` | Custom CMake macros and modules |
+| `python/go4py/` | Python bindings |
+| `MbsAPI/` | MBS event format reader API |
+
+## Coding Conventions
+
+### File Naming
+- Headers: `TModule-name.h` (e.g., `TGo4AnalysisStep.h`)
+- Sources: `TModule-name.cxx` (e.g., `TGo4AnalysisStep.cxx`)
+- Class names match header file names with `T` prefix convention
+
+### Class Naming
+- All Go4 classes prefixed with `TGo4` (e.g., `TGo4Analysis`, `TGo4Command`)
+- Inheritance naming: append role descriptor (e.g., `TGo4AnalysisImp`, `TGo4AnalysisManager`)
+- Commander pattern: `TGo4Com<action>` (e.g., `TGo4ComStart`, `TGo4ComQuit`)
+
+### Header Style
+- Include guard format: `TMODULENAME_H` (uppercase)
+- Go4 header includes use bare names: `#include "TGo4Log.h"` (no path)
+- All headers are copied to `${BUILD_DIR}/include/` during build
+
+### File Header Block
+Every source and header file starts with:
+```cpp
+// $Id$
+//-----------------------------------------------------------------------
+//       The GSI Online Offline Object Oriented (Go4) Project
+//         Experiment Data Processing at EE department, GSI
+//-----------------------------------------------------------------------
+// Copyright (C) 2000- GSI Helmholtzzentrum fuer Schwerionenforschung GmbH
+//                     Planckstr. 1, 64291 Darmstadt, Germany
+// Contact:            http://go4.gsi.de
+//-----------------------------------------------------------------------
+// This software can be used under the license agreements as stated
+// in Go4License.txt file which is part of the distribution.
+//-----------------------------------------------------------------------
+```
+
+### Code Style
+- Tabs for indentation
+- Opening braces on same line for functions/classes
+- Pointer/reference with type: `const char* ptr`, `int& ref`
+- No trailing semicolons after namespace blocks
+
+## Build System
+
+### CMake Macros (from `cmake/modules/Go4Macros.cmake`)
+
+| Macro | Purpose |
+|-------|---------|
+| `GO4_SOURCES(libname HEADERS h1 SOURCES s1)` | Register source/header files for a library |
+| `GO4_STANDARD_LIBRARY(name LINKDEF ... DEPENDENCIES ...)` | Create a Go4 shared library with ROOT dictionary |
+| `GO4_USER_ANALYSIS(HEADERS h1 SOURCES s1 LINKDEF l)` | Build user analysis library |
+| `GO4_INSTALL_HEADERS(h1 h2 ...)` | Copy headers to build include directory |
+| `GO4_LINK_LIBRARY(name SOURCES s1 LIBRARIES l1 DEFINITIONS d1)` | Create a shared library without ROOT dict |
+
+### Common CMake Options
+```bash
+cmake - Dhdf5=ON    # Enable HDF5 support
+cmake -Dqt6=ON      # Use Qt6 instead of Qt5
+cmake -Dgui=ON      # Build GUI components
+cmake -Dexamples=ON # Build example projects
+cmake -Ddabc=ON     # Enable DABC integration
+```
+
+### Build Commands
+```bash
+mkdir build && cd build
+cmake <path_to_source>
+make -j$(nproc)
+source go4login        # Set environment variables
+```
+
+## Development Guidelines
+
+### Adding a New Module
+1. Create directory `Go4<Name>/` with `CMakeLists.txt`
+2. Add `Module.mk` for legacy Make support
+3. Use `GO4_SOURCES` to register files in the parent CMakeLists.txt
+4. Include in appropriate layer's library build
+
+### Adding a New Command
+1. Create `TGo4Com<action>.h` and `TGo4Com<action>.cxx` in appropriate `Go4Commands*/` directory
+2. Inherit from `TGo4Command` base class
+3. Override `Execute()` method
+4. Register in command list's `CreateCommands()` method
+
+### Adding a New Analysis Step
+1. Create step class inheriting `TGo4AnalysisStep`
+2. Override `Init()`, `FillData()`, `ResetLoop()`, `ResetResults()`
+3. Register in user analysis library's CMakeLists.txt
+
+### ROOT Dictionary Generation
+Headers included in `LINKDEF` files get dictionary generation via `ROOT_GENERATE_DICTIONARY`. All public API headers that need interpreter access must be listed in the corresponding `Go4Dict/Go4*LinkDef.h`.
+
+## Platform Support
+
+| Platform | Status |
+|----------|--------|
+| openSUSE Leap/Tumbleweed | Primary development |
+| Debian 7-11 | Supported |
+| macOS 10.14+ | Supported (requires qt5web) |
+| Windows (VS2019) | Supported |
+| GCC 10-13 | Tested |
+
+## Key Environment Variables
+
+After running `source go4login`:
+- `GO4SYS` — Go4 installation/build directory
+- `GO4INC` — Go4 include directory
+- `GO4BIN` — Go4 binaries directory
+- `GO4LIB` — Go4 libraries directory
+
+## Git Remotes
+
+- `origin`: git@github.com:gsi-ee/go4.git
+
+## Useful Paths
+
+| Path | Content |
+|------|---------|
+| `docs/` | PDF manuals (Go4Introduction, Go4Reference, Go4FitTutorial) |
+| `etc/` | Configuration files and startup scripts |
+| `macros/` | ROOT macro files (`.C`) |
+| `html/`, `html5/` | Web interface assets |
+| `data/test.lmd` | Test data file |
+| `docker/` | Docker configurations for various distros |

--- a/Go4Analysis/TGo4AnalysisImp.cxx
+++ b/Go4Analysis/TGo4AnalysisImp.cxx
@@ -432,13 +432,10 @@ Int_t TGo4Analysis::Process()
          {
             rev=-1;
          }
-         //return -1;
          else
          {
-            TDirectory *savdir = gDirectory;
-            gROOT->cd(); // necessary for dynamic list scope
+            TDirectory::TContext ctxt(gROOT);
             MainCycle();
-            savdir->cd();
          }
       }
 
@@ -928,22 +925,20 @@ Bool_t TGo4Analysis::SaveStatus(const char *filename)
 TGo4AnalysisStatus *TGo4Analysis::CreateStatus()
 {
    GO4TRACE((11,"TGo4Analysis::CreateStatus()",__LINE__, __FILE__));
-   TDirectory *filsav = gDirectory;
-   gROOT->cd();
-   TGo4AnalysisStatus *state= new TGo4AnalysisStatus(GetName());
+
+   TDirectory::TContext ctxt(gROOT);
+   auto state = new TGo4AnalysisStatus(GetName());
    UpdateStatus(state);
-   filsav->cd();
    return state;
 }
 
 TGo4AnalysisWebStatus *TGo4Analysis::CreateWebStatus()
 {
    GO4TRACE((11,"TGo4Analysis::CreateWebStatus()",__LINE__, __FILE__));
-   TDirectory *filsav = gDirectory;
-   gROOT->cd();
-   TGo4AnalysisWebStatus *state= new TGo4AnalysisWebStatus(GetName());
+
+   TDirectory::TContext ctxt(gROOT);
+   auto state = new TGo4AnalysisWebStatus(GetName());
    UpdateStatus(state);
-   filsav->cd();
    return state;
 }
 
@@ -2086,7 +2081,8 @@ TGo4ShapedCond *TGo4Analysis::MakeCircleCond(const char *fullname,
            const char *HistoName)
 {
    TGo4ShapedCond *elli = MakeEllipseCond(fullname, npoints, cx, cy, r, r, 0, HistoName);
-   elli->SetCircle(); // mark "circle shape" property
+   if (elli)
+      elli->SetCircle(); // mark "circle shape" property
    return elli;
 }
 
@@ -2094,7 +2090,8 @@ TGo4ShapedCond *TGo4Analysis::MakeBoxCond(const char *fullname, Double_t cx, Dou
                const char *HistoName)
 {
    TGo4ShapedCond *elli = MakeEllipseCond(fullname, 4, cx, cy, a1, a2, theta, HistoName);
-   elli->SetBox(); // convert to  "box shape" property
+   if (elli)
+      elli->SetBox(); // convert to  "box shape" property
    return elli;
 }
 
@@ -2103,8 +2100,9 @@ TGo4ShapedCond *TGo4Analysis::MakeFreeShapeCond(const char *fullname,
                                    Double_t (*points) [2],
                                    const char *HistoName)
 {
-   TGo4ShapedCond *elli=dynamic_cast<TGo4ShapedCond*>(MakePolyCond(fullname, npoints, points, HistoName,true));
-   elli->SetFreeShape();
+   TGo4ShapedCond *elli = dynamic_cast<TGo4ShapedCond*>(MakePolyCond(fullname, npoints, points, HistoName,true));
+   if (elli)
+      elli->SetFreeShape();
    return elli;
 }
 

--- a/Go4Analysis/TGo4AnalysisImp.cxx
+++ b/Go4Analysis/TGo4AnalysisImp.cxx
@@ -296,6 +296,7 @@ TGo4Analysis::~TGo4Analysis()
    SafeDelete(fxSampleEvent);
    TGo4CommandInvoker::UnRegister(this);
    fxInstance = nullptr; // reset static singleton instance pointer
+   fbExists = kFALSE; // reset static flag which indicate existance of analysis instance
    gROOT->ProcessLineSync(TString::Format(".x %s", TGo4Log::subGO4SYS("macros/anamacroclose.C").Data()).Data());
 }
 

--- a/Go4Analysis/TGo4AnalysisImp.cxx
+++ b/Go4Analysis/TGo4AnalysisImp.cxx
@@ -993,9 +993,9 @@ Int_t TGo4Analysis::PreLoop()
    fiAutoSaveCount = 0;
    Int_t rev = UserPreLoop();
    for (Int_t num = 0; num < fxStepManager->GetNumberOfAnalysisSteps(); num++) {
-      TGo4AnalysisStep *step = fxStepManager->GetAnalysisStepNum(num);
-      TGo4EventProcessor *proc = step ? step->GetEventProcessor() : nullptr;
-      if (proc) proc->UserPreLoop();
+      if (auto step = fxStepManager->GetAnalysisStepNum(num))
+         if (auto proc = step->GetEventProcessor())
+            proc->UserPreLoop();
    }
 
    fxAutoSaveClock->Start(kTRUE);
@@ -1017,9 +1017,9 @@ Int_t TGo4Analysis::PostLoop()
    /////////////////////
    if(fbInitIsDone) {
       for (Int_t num = 0; num < fxStepManager->GetNumberOfAnalysisSteps(); num++) {
-         TGo4AnalysisStep *step = fxStepManager->GetAnalysisStepNum(num);
-         TGo4EventProcessor *proc = step ? step->GetEventProcessor() : nullptr;
-         if (proc) proc->UserPostLoop();
+         if (auto step = fxStepManager->GetAnalysisStepNum(num))
+            if (auto proc = step->GetEventProcessor())
+               proc->UserPostLoop();
       }
 
       rev = UserPostLoop(); // do not call userpostloop after error in initialization

--- a/Go4Analysis/TGo4AnalysisImp.cxx
+++ b/Go4Analysis/TGo4AnalysisImp.cxx
@@ -268,8 +268,8 @@ void TGo4Analysis::Constructor()
       Message(2,"Analysis BaseClass ctor -- analysis singleton already exists !!!");
    }
    // settings for macro execution
-   TInterpreter* theI = gROOT->GetInterpreter();
-   theI->SetProcessLineLock(kTRUE); // mandatory for ROOT > 6.12
+   if (auto theI = gROOT->GetInterpreter())
+      theI->SetProcessLineLock(kTRUE); // mandatory for ROOT > 6.12
 
    gROOT->ProcessLineSync("TGo4Analysis *go4 = TGo4Analysis::Instance();");
    gROOT->ProcessLineSync(TString::Format(".x %s", TGo4Log::subGO4SYS("macros/anamacroinit.C").Data()).Data());

--- a/Go4Analysis/TGo4AnalysisImp.cxx
+++ b/Go4Analysis/TGo4AnalysisImp.cxx
@@ -248,7 +248,7 @@ void TGo4Analysis::Constructor()
       fxAutoFileName = fgcDEFAULTFILENAME;
       if (fAnalysisName.Length()>0) fxAutoFileName = TString::Format("%sASF.root", fAnalysisName.Data());
       fxConfigFilename = fgcDEFAULTSTATUSFILENAME;
-      fxDefaultTestFileName=TString::Format("%s/data/test.lmd",getenv("GO4SYS"));
+      fxDefaultTestFileName = TGo4Log::subGO4SYS("data/test.lmd");
 
       TGo4CommandInvoker::Instance(); // make sure we have an invoker instance!
       TGo4CommandInvoker::SetCommandList(new TGo4AnalysisCommandList);

--- a/Go4Analysis/TGo4AnalysisImp.cxx
+++ b/Go4Analysis/TGo4AnalysisImp.cxx
@@ -792,8 +792,7 @@ Int_t TGo4Analysis::RunImplicitLoop(Int_t times, Bool_t showrate, Double_t proce
    if (showrate) {
       printf("\n"); fflush(stdout);
    }
-   delete fxRate;
-   fxRate = nullptr;
+   SafeDelete(fxRate);
    /////////// end outer catch block
    return cnt;
 }
@@ -847,10 +846,11 @@ Bool_t TGo4Analysis::LoadStatus(const char *filename)
    GO4TRACE((11,"TGo4Analysis::LoadStatus(const char *)",__LINE__, __FILE__));
    //
    Bool_t rev = kFALSE;
-   TString fname = filename ? filename : fgcDEFAULTSTATUSFILENAME;
+   TString fname = filename && *filename ? filename : fgcDEFAULTSTATUSFILENAME;
 
    // file suffix if not given by user
-   if(!fname.Contains(fgcDEFAULTFILESUF)) fname.Append(fgcDEFAULTFILESUF);
+   if(!fname.Contains(fgcDEFAULTFILESUF))
+      fname.Append(fgcDEFAULTFILESUF);
 
    TFile *statusfile = TFile::Open(fname.Data(), "READ");
    if(statusfile && statusfile->IsOpen()) {
@@ -908,7 +908,6 @@ Bool_t TGo4Analysis::SaveStatus(const char *filename)
       if(state) {
          state->Write();
          delete state;
-         delete statusfile;
          rev = kTRUE;
          Message(-1,"Analysis SaveStatus: Saved Analysis settings to file %s", buffer);
       } else {
@@ -920,6 +919,9 @@ Bool_t TGo4Analysis::SaveStatus(const char *filename)
             buffer);
       rev = kFALSE;
    }  // if(statusfile && statusfile->IsOpen())
+
+   delete statusfile;
+
    return rev;
 }
 

--- a/Go4Analysis/TGo4AnalysisImp.cxx
+++ b/Go4Analysis/TGo4AnalysisImp.cxx
@@ -283,19 +283,17 @@ TGo4Analysis::~TGo4Analysis()
    InstallGo4CtrlCHandler(false);
 #endif
 
-   if (fxInterruptHandler) {
-      delete fxInterruptHandler;
-      fxInterruptHandler = nullptr;
-   }
+   SafeDelete(fxInterruptHandler);
 
    GO4TRACE((15,"TGo4Analysis::~TGo4Analysis()",__LINE__, __FILE__));
    CloseAnalysis();
    CloseAutoSaveFile();
-   delete fxStepManager;
-   delete fxObjectManager;
-   delete fxObjectNames;
-   delete fxAutoSaveClock;
-   delete fxSampleEvent;
+   SafeDelete(fxStepManager);
+   SafeDelete(fxObjectManager);
+   SafeDelete(fxObjectNames);
+   SafeDelete(fxAutoSaveClock);
+   SafeDelete(fxAutoSaveMutex);
+   SafeDelete(fxSampleEvent);
    TGo4CommandInvoker::UnRegister(this);
    fxInstance = nullptr; // reset static singleton instance pointer
    gROOT->ProcessLineSync(TString::Format(".x %s", TGo4Log::subGO4SYS("macros/anamacroclose.C").Data()).Data());

--- a/Go4EventServerExample/MainGo4EventServerExample.cxx
+++ b/Go4EventServerExample/MainGo4EventServerExample.cxx
@@ -85,7 +85,7 @@ int main(int argc, char **argv)
      // the input. Please change subclass of TGo4EventSource
      // to change input type.
 /////////// MBS LISTMODE FILE /////////////////////////////////////////////
-     TString testfilename = TString::Format("%s/data/test.lmd",getenv("GO4SYS")); // this file is part of go4 distribution
+     TString testfilename = TGo4Log::subGO4SYS("data/test.lmd"); // this file is part of go4 distribution
      input = new TGo4MbsFile(testfilename.Data());
 //         input= new TGo4MbsFile("dat0.lmd");
         // for listmode file with given path and name

--- a/Go4Example1Step/TXXXAnalysis.cxx
+++ b/Go4Example1Step/TXXXAnalysis.cxx
@@ -41,8 +41,6 @@ TXXXAnalysis::TXXXAnalysis(int argc, char **argv) :
    factory->DefEventProcessor("XXXProc","TXXXProc");// object name, class name
    factory->DefOutputEvent("XXXEvent","TXXXEvent"); // object name, class name
 
-//   Text_t lmdfile[512]; // source file
-//   sprintf(lmdfile,"%s/data/test.lmd",getenv("GO4SYS"));
    // TGo4EventSourceParameter *sourcepar = new TGo4MbsTransportParameter("r3b");
    TGo4EventSourceParameter *sourcepar = new TGo4MbsFileParameter(GetDefaultTestFileName());
 

--- a/Go4ExampleAdvanced/setup.C
+++ b/Go4ExampleAdvanced/setup.C
@@ -15,11 +15,9 @@ void setup(const char *kind, const char *name)
 // odir/name_AS
 // odir/name_unpacked
 // odir/name_analyzed
-  Text_t sourcedir[512]; // source directory
 
 // steering parameters to modify:
-  sprintf(sourcedir,"%s/data",getenv("GO4SYS"));
-  TString inpath(sourcedir);  // input directory
+  TString inpath = TGo4Log::subGO4SYS("data");  // input directory
   TString outpath("."); // output directory
 
   TString unpackSource(kind); // -file, -stream, -transport, -random

--- a/Go4ExampleUserStore/TXXXAnalysis.cxx
+++ b/Go4ExampleUserStore/TXXXAnalysis.cxx
@@ -43,8 +43,6 @@ TXXXAnalysis::TXXXAnalysis(int argc, char **argv) :
    factory->DefOutputEvent("XXXEvent","TXXXEvent"); // object name, class name
    factory->DefUserEventStore("TXXXStore"); // class name
 
-//   Text_t lmdfile[512]; // source file
-//   sprintf(lmdfile,"%s/data/test.lmd",getenv("GO4SYS"));
    // TGo4EventSourceParameter *sourcepar = new TGo4MbsTransportParameter("r3b");
    TGo4EventSourceParameter *sourcepar = new TGo4MbsFileParameter(GetDefaultTestFileName());
 


### PR DESCRIPTION
1. Fix memory leak in destructor - ASF mutex
2. Use SafeDelete() method of ROOT for main analysis objects
3. Avoid usage of getenv("GO4SYS") in printf - unsafe if nullptr returned
4. Reset fbExists flag when analysis instance reset to nullptr